### PR TITLE
must monotonically increasing

### DIFF
--- a/streamer/streamer.cpp
+++ b/streamer/streamer.cpp
@@ -12,10 +12,11 @@ namespace streamer
 
 static int64_t timems()
 {
-    struct timeval tv;
-    
-    gettimeofday(&tv, NULL);
-    return (tv.tv_sec*1000 + tv.tv_usec/1000);
+    struct timespec now;
+
+    clock_gettime(CLOCK_BOOTTIME,&now);
+
+    return (now.tv_sec*1000 + now.tv_nsec/1000/1000);
 }
 
 #define STREAM_PIX_FMT    AV_PIX_FMT_YUV420P


### PR DESCRIPTION
使用 linux 的单调递增时间函数，使用 CLOCK_BOOTTIME
CLOCK_MONOTONIC
CLOCK_MONOTONIC_RAW
在 windows docker 容器下测试都不生效